### PR TITLE
Remove the fair corpse player model

### DIFF
--- a/lua/autorun/server/sv_model_regulator.lua
+++ b/lua/autorun/server/sv_model_regulator.lua
@@ -2,7 +2,6 @@ local defaultModel = "models/player/kleiner.mdl"
 
 local modelIsProhibited = {}
 modelIsProhibited["models/player/skeleton.mdl"] = true
-modelIsProhibited["models/player/corpse1.mdl"]  = true
 modelIsProhibited["models/player/charple.mdl"]  = true
 
 local playerMeta = FindMetaTable("Player")


### PR DESCRIPTION
Our friend on discord gave me pictures that indicated the corpse model has a very similar hitbox to Kleiner, and I don't believe it's visually harder to see.

Open to discussion.