### PR TITLE
Add zombine to blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# cfc_player_model_regulator
+Restricts certain playermodels and prevents them from showing up in the selection menu.

--- a/lua/autorun/server/sv_model_regulator.lua
+++ b/lua/autorun/server/sv_model_regulator.lua
@@ -3,6 +3,7 @@ local defaultModel = "models/player/kleiner.mdl"
 local modelIsProhibited = {}
 modelIsProhibited["models/player/skeleton.mdl"] = true
 modelIsProhibited["models/player/charple.mdl"]  = true
+modelIsProhibited["models/player/zombie_soldier.mdl"]  = true
 
 local playerMeta = FindMetaTable( "Player" )
 local entityMeta = FindMetaTable( "Entity" )

--- a/lua/autorun/sh_model_regulator.lua
+++ b/lua/autorun/sh_model_regulator.lua
@@ -1,2 +1,3 @@
 player_manager.AllValidModels()["skeleton"] = nil
 player_manager.AllValidModels()["charple"] = nil
+player_manager.AllValidModels()["zombine"] = nil


### PR DESCRIPTION
Prevents the use of the `zombine` model, a head less playermodel.

![image](https://user-images.githubusercontent.com/69946827/156854633-dc13f608-279b-4922-a0e3-44d9acb0de13.png)
![image](https://user-images.githubusercontent.com/69946827/156854674-b37df119-67f2-49c1-8688-ca2def7913c2.png)
